### PR TITLE
fix(e2e): mars curiosity-cross-link CI flake — deterministic readiness signal

### DIFF
--- a/tests/e2e/mars.spec.ts
+++ b/tests/e2e/mars.spec.ts
@@ -73,21 +73,32 @@ test.describe('/mars', () => {
 
   test('curiosity panel surfaces FULL MISSION CARD cross-link', async ({ page }) => {
     await page.goto('/mars?site=curiosity');
-    // Drop `waitForLoadState('networkidle')` — /mars keeps streaming
-    // canvas textures + traverse polylines well past the 500 ms
-    // network-quiet window networkidle needs, so on mobile-chromium
-    // under CI load the wait ate the entire 30 s test budget before
-    // the panel even got asserted. The panel.toBeVisible() below is
-    // the actual readiness signal we need (issue #222).
+    // Deterministic readiness: wait for the sites JSON to land before
+    // asserting on the panel. `canvas.layer` exposes `data-sites-count`
+    // which flips from '0' to the resolved site count once
+    // `getMarsSites()` (a chain of N+2 sequential fetches: list + hotspots
+    // + one i18n overlay per site) resolves and `selectSite` runs from
+    // the URL-param path. Without this wait, `panel.toBeVisible` raced
+    // the fetch chain on mobile-chromium under GH Actions load and
+    // exceeded 10 s consistently. The previous comment claimed
+    // `waitForLoadState('networkidle')` ate the 30 s budget — that's
+    // still true, but this signal is more specific (the actual thing
+    // gating panel visibility) and bounded. Two other tests in this
+    // file (?site=curiosity at L57 and ?site=mro at L65) still use
+    // networkidle and pass; this test had additional cross-link
+    // hydration that pushed it past the network-quiet window.
+    // Issue #228-followup (CI regression on top of #222 retry-pass fix).
+    await expect(page.locator('canvas.layer')).not.toHaveAttribute('data-sites-count', '0', {
+      timeout: 15_000,
+    });
     const panel = page.getByRole('complementary');
-    await expect(panel).toBeVisible({ timeout: 10_000 });
+    // Panel opens synchronously inside the sites-loaded .then() block,
+    // so once the sites attribute flips, the panel is already mounted.
+    // 5 s is plenty for the in-fly transition.
+    await expect(panel).toBeVisible({ timeout: 5_000 });
     const link = panel.getByRole('link', { name: /FULL MISSION CARD/i });
-    // The cross-link list hydrates after the panel mounts (it depends
-    // on the site→mission resolver fetching the mission JSON). On
-    // mobile-chromium under CI load this exceeded the default 5 s
-    // toBeVisible timeout (test was timing out before the locator
-    // even resolved). 10 s gives 2× margin without masking a real
-    // regression. Issue #222 (flaky retry-pass in v0.6.2).
+    // Cross-link still hydrates after the panel mounts (mission JSON
+    // fetch). 10 s margin retained.
     await expect(link).toBeVisible({ timeout: 10_000 });
     await expect(link).toHaveAttribute('href', /\/missions\?id=curiosity/);
   });


### PR DESCRIPTION
## Summary

Fixes the e2e gate that has been blocking auto-deploy on `main` since v0.6.3 push.

Three consecutive GitHub Actions e2e runs failed on the same test:
> ✘ [mobile-chromium] mars.spec.ts:74 › /mars › curiosity panel surfaces FULL MISSION CARD cross-link (11.7s, 22.5s retry)

Failures: [25972031168](https://github.com/chipi/orrery/actions/runs/25972031168) · [25973007627](https://github.com/chipi/orrery/actions/runs/25973007627)

## Root cause

The test fired `panel.toBeVisible()` immediately after `page.goto()`, racing the async chain that `getMarsSites()` runs — `mars-sites.json` + `surface-hotspots-sidecar` + N sequential i18n overlay fetches (one per site, awaited in a `for` loop). On mobile-chromium under CI load the chain consistently exceeded the 10 s panel timeout; the v0.6.2 #222 bump from 5 s to 10 s was insufficient now that the catalogue has grown.

The v0.6.2 comment dropped `waitForLoadState('networkidle')` because mars streams canvas textures past the 500 ms quiet window, eating the 30 s test budget. That diagnosis was correct but the alternative was a bare timeout, which doesn't actually verify sites have loaded.

## Fix

Wait on `canvas.layer[data-sites-count != "0"]` before asserting on the panel. This is the specific signal that `getMarsSites()` has resolved and `selectSite()` has fired from the URL-param path. Same readiness signal the `'no console errors on load'` test at line 106 already uses. Once the attribute flips, the panel is mounted synchronously inside the `.then()` block, so the subsequent `toBeVisible()` resolves in <100 ms.

## Test plan

- [x] Reproduced the failure locally with stock 10 s timeout under throttled fetch
- [x] Verified the fix passes on `mobile-chromium`: test runs in 2.3 s (was 11.7 s + retry)
- [x] Verified the fix doesn't break `mars.spec.ts` siblings: full file 7/7 pass on mobile-chromium in 14.9 s
- [ ] CI e2e gate goes green on this PR
- [ ] Merge → auto-deploy unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)